### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PLANET4_SELENIUM_URL https://github.com/greenpeace/planet4-selenium-tests
 
 USER root
 
-RUN apt update && apt -y install \
+RUN apt-get update && apt-get -y install \
     libmcrypt-dev \
     libxml2 \
     libxml2-dev \


### PR DESCRIPTION
Resolves WARNING: apt does not have a stable CLI interface. Use with
caution in scripts.
Apt is a high-level user-interface command, like git porcelain commands
and output may change in future.